### PR TITLE
UMD wrapper so it can be used without build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules
+/dist/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "prebuild": "mkdir -p dist",
-    "build": "umd blacklist index.js dist/blacklist.js",
+    "build": "umd --commonJS blacklist index.js dist/blacklist.js",
     "postbuild": "uglifyjs dist/blacklist.js > dist/blacklist.min.js",
     "prepublish": "npm run build",
     "standard": "standard",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "prebuild": "mkdir -p dist",
     "build": "umd blacklist index.js dist/blacklist.js",
+    "postbuild": "uglifyjs dist/blacklist.js > dist/blacklist.min.js",
     "prepublish": "npm run build",
     "standard": "standard",
     "test": "mocha --reporter list -t 20000 test/index.js"
@@ -29,6 +30,7 @@
   "devDependencies": {
     "mocha": "^2.2.1",
     "standard": "^3.3.0",
+    "uglify-js": "^2.6.1",
     "umd": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/dcousens/blacklist/issues"
   },
   "scripts": {
+    "prebuild": "mkdir -p dist",
+    "build": "umd blacklist index.js dist/blacklist.js",
+    "prepublish": "npm run build",
     "standard": "standard",
     "test": "mocha --reporter list -t 20000 test/index.js"
   },
@@ -25,6 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "^2.2.1",
-    "standard": "^3.3.0"
+    "standard": "^3.3.0",
+    "umd": "^3.0.1"
   }
 }


### PR DESCRIPTION
Ignored in git, only present in npm package when published.

So it can be used in a browser directly, through npmcdn
